### PR TITLE
V3 - Implement Pagination for Comic List

### DIFF
--- a/lib/core/contracts/i_comic_repository.dart
+++ b/lib/core/contracts/i_comic_repository.dart
@@ -3,6 +3,6 @@ import 'package:comic_vine_app/features/comic_vine/data/models/comic_model.dart'
 /// ComicRepository defines the contract for fetching comics data,
 /// allowing for different implementations (mock data, API, etc.).
 abstract class ComicRepository {
-  Future<List<ComicModel>> fetchComics();
+  Future<List<ComicModel>> fetchComics(int offset);
   Future<ComicModel> fetchComicDetail(int id);
 }

--- a/lib/core/widgets/dot_loading_indicator.dart
+++ b/lib/core/widgets/dot_loading_indicator.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 /// often used as a loading indicator. The size of the dots can be adjusted, and
 /// the animation provides a fade-in, fade-out effect.
 class DotLoadingIndicator extends StatefulWidget {
-  const DotLoadingIndicator({super.key});
+  final double size;
+  const DotLoadingIndicator({super.key, this.size = 60.0});
 
   @override
   State<DotLoadingIndicator> createState() => _DotLoadingIndicatorState();
@@ -56,8 +57,8 @@ class _DotLoadingIndicatorState extends State<DotLoadingIndicator> with SingleTi
                 ),
                 child: Container(
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),  // Increase spacing between dots
-                  width: 60.0,  // Increased size for larger dots
-                  height: 60.0, // Increased size for larger dots
+                  width: widget.size,  // Increased size for larger dots
+                  height: widget.size, // Increased size for larger dots
                   decoration: const BoxDecoration(
                     color: Colors.black,
                     shape: BoxShape.circle,      // Circular shape for each dot

--- a/lib/features/comic_vine/data/repositories/comic_repository_api.dart
+++ b/lib/features/comic_vine/data/repositories/comic_repository_api.dart
@@ -12,8 +12,9 @@ class ComicRepositoryAPI implements ComicRepository {
 
   /// Fetches a list of comics from the Comic Vine API
   @override
-  Future<List<ComicModel>> fetchComics() async {
-    final String url = '${config.baseUrl}/issues/?api_key=${config.apiKey}';
+  @override
+  Future<List<ComicModel>> fetchComics(int offset) async {
+    final String url = '${config.baseUrl}/issues/?api_key=${config.apiKey}&offset=$offset&limit=15';
 
     try {
       final response = await http.get(Uri.parse(url));
@@ -41,6 +42,7 @@ class ComicRepositoryAPI implements ComicRepository {
       throw Exception('Error fetching comics: $e');
     }
   }
+
 
   /// Fetches details of a specific comic by its ID
   @override

--- a/lib/features/comic_vine/data/repositories/comic_repository_mock.dart
+++ b/lib/features/comic_vine/data/repositories/comic_repository_mock.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 /// Implementation of ComicRepository using mock data stored in a JSON file.
 class ComicRepositoryMock implements ComicRepository {
   @override
-  Future<List<ComicModel>> fetchComics() async {
+  Future<List<ComicModel>> fetchComics(int offset) async {
     try {
       final String response = await rootBundle.loadString('assets/mock_data/comics.json');
       final List<dynamic> data = jsonDecode(response);

--- a/lib/features/comic_vine/presentation/blocs/comic/comic_event.dart
+++ b/lib/features/comic_vine/presentation/blocs/comic/comic_event.dart
@@ -8,8 +8,16 @@ abstract class ComicEvent extends Equatable {
   List<Object> get props => [];
 }
 
-/// Event to fetch the list of comics
-class FetchComics extends ComicEvent {}
+/// Event to fetch the list of comics, supporting pagination
+class FetchComics extends ComicEvent {
+  final int page;
+
+  const FetchComics({required this.page});
+
+  @override
+  List<Object> get props => [page];
+}
+
 
 /// Event to fetch details of a specific comic by ID
 class FetchComicDetail extends ComicEvent {

--- a/lib/features/comic_vine/presentation/blocs/comic/comic_state.dart
+++ b/lib/features/comic_vine/presentation/blocs/comic/comic_state.dart
@@ -6,7 +6,7 @@ abstract class ComicState extends Equatable {
   const ComicState();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 /// State when comics are being loaded
@@ -41,3 +41,14 @@ class ComicDetailLoaded extends ComicState {
   @override
   List<Object> get props => [comic];
 }
+
+
+/// State when more comics are being loaded
+class ComicLoadingMore extends ComicLoaded {
+  const ComicLoadingMore(super.comics);
+
+  @override
+  List<Object> get props => [comics];
+}
+
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:comic_vine_app/features/comic_vine/data/repositories/comic_repos
 import 'package:flutter/material.dart';
 import 'package:comic_vine_app/core/contracts/i_theme_config.dart';
 import 'package:comic_vine_app/core/theme/app_theme.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:comic_vine_app/app/app_root.dart';
 import 'package:comic_vine_app/core/contracts/i_comic_repository.dart';
@@ -44,5 +45,13 @@ void setupLocator() {
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   setupLocator();
-  runApp(const AppRoot());
+  runApp(MultiBlocProvider(
+    providers: [
+      BlocProvider<ComicBloc>(
+        create: (context) => ComicBloc(GetIt.I<ComicRepository>()),
+      ),
+    ],
+    child: const AppRoot(),
+  ),
+  );
 }


### PR DESCRIPTION
- Implemented infinite scroll pagination in the comic list view.
- Each API call fetches 15 comics per request, appending them to the list.
- Maintained all features from V2, including data fetching, loading states, and error handling.
- Added support for loading more comics as the user scrolls down.
- Improved Bloc logic to handle pagination and manage the offset for fetching the next set of comics.